### PR TITLE
Task 3: Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -34,5 +34,6 @@
 .iconCollapsed {
   width: space.$s6;
   margin-right: space.$s3;
-  transform: scaleX(-1);
+
+  // transform: scaleX(-1);
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -146,6 +146,10 @@
 .collapseMenuItem {
   display: none;
 
+  &.isCollapsed {
+    transform: scaleX(-1);
+  }
+
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -99,7 +99,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -1,4 +1,4 @@
-// import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes } from "react";
 import classNames from "classnames";
 import styles from "./button.module.scss";
 
@@ -32,14 +32,11 @@ export enum ButtonState {
 //   only = "only",
 // }
 
-type ButtonProps = {
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode;
   size?: ButtonSize;
   color?: ButtonColor;
   state?: ButtonState;
-  className?: string;
-  onClick?: () => void;
-  // icon?: ButtonIcon;
 };
 
 export function Button({
@@ -49,20 +46,24 @@ export function Button({
   state = ButtonState.default,
   className,
   onClick,
+  disabled,
+  ...rest
 }: ButtonProps) {
   return (
-    <div
+    <button
       className={classNames(
-        styles.container,
+        styles.button,
         styles[size],
         styles[color],
         styles[state],
         className,
       )}
+      disabled={disabled}
       onClick={onClick}
+      {...rest}
     >
       {children}
-    </div>
+    </button>
   );
 }
 


### PR DESCRIPTION
Fix: previous commit to Sidebar Navigation: Arrow should point to the right when collapsed flipped the support.svg too. Fixed the issue, now only the arrow flips